### PR TITLE
rebuild sentencepiece 0.2.0 to include missing header

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,8 @@ source:
     # backport of https://github.com/google/sentencepiece/pull/979:
     # avoid having to specify CMAKE_INSTALL_{LIB,INCLUDE}DIR due to wrong order
     - patches/0007-move-setting-of-default-CMAKE_INSTALL_-BIN-INCLUDE-L.patch
+    # this header file gets built along with other ones and occasionally is neeeded downstream (e.g. fairseq2)
+    - patches/0008-include-sentencepiece_model-in-package.patch
 
 build:
   number: 2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ source:
     - patches/0008-include-sentencepiece_model-in-package.patch
 
 build:
-  number: 2
+  number: 3
 
 outputs:
   - name: sentencepiece

--- a/recipe/patches/0001-do-not-mix-static-shared-builds.patch
+++ b/recipe/patches/0001-do-not-mix-static-shared-builds.patch
@@ -1,7 +1,7 @@
 From 2fe3e37744c810590e631c01fb57133080fc5f46 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Thu, 2 Dec 2021 08:39:53 +1100
-Subject: [PATCH 1/7] do not mix static & shared builds
+Subject: [PATCH 1/8] do not mix static & shared builds
 
 ---
  src/CMakeLists.txt | 20 ++++++++++----------

--- a/recipe/patches/0002-ensure-we-set-PROTOBUF_USE_DLLS-when-using-our-own-p.patch
+++ b/recipe/patches/0002-ensure-we-set-PROTOBUF_USE_DLLS-when-using-our-own-p.patch
@@ -1,7 +1,7 @@
 From 185e8cd8603d188cccdb6f170a60d2984211b70c Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Thu, 2 Dec 2021 10:05:12 +1100
-Subject: [PATCH 2/7] ensure we set PROTOBUF_USE_DLLS when using our own
+Subject: [PATCH 2/8] ensure we set PROTOBUF_USE_DLLS when using our own
  protobuf
 
 ---

--- a/recipe/patches/0003-point-to-our-libs-headers-for-windows-in-setup.py.patch
+++ b/recipe/patches/0003-point-to-our-libs-headers-for-windows-in-setup.py.patch
@@ -1,7 +1,7 @@
 From fec0f2f37c4c35057c31757de3ff0704afcb37d3 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Sun, 11 Dec 2022 01:09:03 +1100
-Subject: [PATCH 3/7] point to our libs / headers for windows in setup.py
+Subject: [PATCH 3/8] point to our libs / headers for windows in setup.py
 
 also do not risk building against bundled libs, nor
 setting /MT for the MSVC static runtime libs

--- a/recipe/patches/0004-also-install-pkg-config-files-on-windows.patch
+++ b/recipe/patches/0004-also-install-pkg-config-files-on-windows.patch
@@ -1,7 +1,7 @@
 From e05172c6bfab80fd02d50d8bafad25cca19edee7 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Mon, 12 Dec 2022 14:36:45 +1100
-Subject: [PATCH 4/7] also install pkg-config files on windows
+Subject: [PATCH 4/8] also install pkg-config files on windows
 
 ---
  CMakeLists.txt | 4 +---

--- a/recipe/patches/0005-create-and-install-CMake-metadata.patch
+++ b/recipe/patches/0005-create-and-install-CMake-metadata.patch
@@ -1,7 +1,7 @@
 From b41a7c9f4ee6efd11a1a265fcb833579098effd1 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Wed, 18 Jan 2023 19:44:15 +1100
-Subject: [PATCH 5/7] create and install CMake metadata
+Subject: [PATCH 5/8] create and install CMake metadata
 
 ---
  CMakeLists.txt               | 10 ++++++++++

--- a/recipe/patches/0006-also-link-to-static-absl_flags_-on-windows.patch
+++ b/recipe/patches/0006-also-link-to-static-absl_flags_-on-windows.patch
@@ -1,7 +1,7 @@
 From d830e3c7a9a395f7db04c737dffa6771add78eb7 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Tue, 20 Feb 2024 17:43:23 +1100
-Subject: [PATCH 6/7] also link to static absl_flags_* on windows
+Subject: [PATCH 6/8] also link to static absl_flags_* on windows
 
 ---
  python/setup.py | 10 +++++++++-

--- a/recipe/patches/0007-move-setting-of-default-CMAKE_INSTALL_-BIN-INCLUDE-L.patch
+++ b/recipe/patches/0007-move-setting-of-default-CMAKE_INSTALL_-BIN-INCLUDE-L.patch
@@ -1,7 +1,7 @@
 From 2e30e979aa1d4b6ef58c9885537736ed6566e26c Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Tue, 20 Feb 2024 18:43:25 +1100
-Subject: [PATCH 7/7] move setting of default
+Subject: [PATCH 7/8] move setting of default
  CMAKE_INSTALL_{BIN,INCLUDE,LIB}DIR before first use
 
 also unify spelling of CMAKE_INSTALL_INCLUDEDIR following GNUInstallDirs

--- a/recipe/patches/0008-include-sentencepiece_model-in-package.patch
+++ b/recipe/patches/0008-include-sentencepiece_model-in-package.patch
@@ -1,0 +1,11 @@
+--- src/CMakeLists.txt	2024-10-09 22:12:52.284579786 +0200
++++ src/CMakeLists.txt	2024-10-09 22:13:21.707444464 +0200
+@@ -333,7 +333,7 @@
+ install(FILES sentencepiece_trainer.h sentencepiece_processor.h
+   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+ if (NOT SPM_PROTOBUF_PROVIDER STREQUAL "internal")
+-  install(FILES ${SPM_PROTO_HDRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++  install(FILES ${SPM_PROTO_HDRS} builtin_pb/sentencepiece_model.pb.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+ endif()
+ 
+ file(TO_NATIVE_PATH "${PROJECT_SOURCE_DIR}/data" data_dir)

--- a/recipe/patches/0008-include-sentencepiece_model.pb.h-in-package.patch
+++ b/recipe/patches/0008-include-sentencepiece_model.pb.h-in-package.patch
@@ -1,22 +1,21 @@
-From acd9f7e7bd2eda3cb32ce27ab099508e3c4a1bca Mon Sep 17 00:00:00 2001
+From 571b24f0302b4a423e5204dd676dc91462632852 Mon Sep 17 00:00:00 2001
 From: Jack Olivieri <jolivieri@anaconda.com>
 Date: Wed, 9 Oct 2024 22:24:40 +0200
 Subject: [PATCH 8/8] include sentencepiece_model.pb.h in package
 
 ---
- src/CMakeLists.txt | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ src/CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
 
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index a612357..0fa5e4d 100644
+index a612357..7e04009 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -333,7 +333,7 @@ install(EXPORT sentencepieceTargets
- install(FILES sentencepiece_trainer.h sentencepiece_processor.h
+@@ -334,6 +334,7 @@ install(FILES sentencepiece_trainer.h sentencepiece_processor.h
    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
  if (NOT SPM_PROTOBUF_PROVIDER STREQUAL "internal")
--  install(FILES ${SPM_PROTO_HDRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-+  install(FILES ${SPM_PROTO_HDRS} builtin_pb/sentencepiece_model.pb.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+   install(FILES ${SPM_PROTO_HDRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++  install(FILES ${SPM_MODEL_PROTO_HDRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
  endif()
  
  file(TO_NATIVE_PATH "${PROJECT_SOURCE_DIR}/data" data_dir)

--- a/recipe/patches/0008-include-sentencepiece_model.pb.h-in-package.patch
+++ b/recipe/patches/0008-include-sentencepiece_model.pb.h-in-package.patch
@@ -1,0 +1,25 @@
+From acd9f7e7bd2eda3cb32ce27ab099508e3c4a1bca Mon Sep 17 00:00:00 2001
+From: Jack Olivieri <jolivieri@anaconda.com>
+Date: Wed, 9 Oct 2024 22:24:40 +0200
+Subject: [PATCH 8/8] include sentencepiece_model.pb.h in package
+
+---
+ src/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index a612357..0fa5e4d 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -333,7 +333,7 @@ install(EXPORT sentencepieceTargets
+ install(FILES sentencepiece_trainer.h sentencepiece_processor.h
+   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+ if (NOT SPM_PROTOBUF_PROVIDER STREQUAL "internal")
+-  install(FILES ${SPM_PROTO_HDRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++  install(FILES ${SPM_PROTO_HDRS} builtin_pb/sentencepiece_model.pb.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+ endif()
+ 
+ file(TO_NATIVE_PATH "${PROJECT_SOURCE_DIR}/data" data_dir)
+-- 
+2.39.5 (Apple Git-154)
+


### PR DESCRIPTION
sentencepiece 0.2.0 

**Destination channel:** Defaults

### Links

- [PKG-5896]
- dev_url:        https://github.com/google/sentencepiece/tree/v0.2.0
- conda_forge:    None
- pypi:           n/a
- pypi inspector: n/a

### Explanation of changes:

- new version number


[PKG-5896]: https://anaconda.atlassian.net/browse/PKG-5896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ