### PR TITLE
sentencepiece 0.2.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313: yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,10 +46,9 @@ outputs:
         - {{ pin_subpackage('sentencepiece-spm', exact=True) }}
         - sentencepiece-python {{ version }} # don't pin_subpackage; that would pin to a single python version
     test:
-      imports:
-        # The linter wants something imported because we mentioned
-        # python in host
-        - sys
+      commands:
+        # tested in other outputs
+        - exit 0
 
   - name: libsentencepiece
     script: build-lib.sh   # [unix]
@@ -212,3 +211,5 @@ extra:
     - oblute
     - h-vetinari
   feedstock-name: sentencepiece
+  skip-lints:
+    - missing_imports_or_run_test_py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ source:
     - patches/0007-move-setting-of-default-CMAKE_INSTALL_-BIN-INCLUDE-L.patch
 
 build:
-  number: 2
+  number: 3
 
 outputs:
   - name: sentencepiece

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,9 +46,10 @@ outputs:
         - {{ pin_subpackage('sentencepiece-spm', exact=True) }}
         - sentencepiece-python {{ version }} # don't pin_subpackage; that would pin to a single python version
     test:
-      commands:
-        # tested in other outputs
-        - exit 0
+      imports:
+        # The linter wants something imported because we mentioned
+        # python in host
+        - sys
 
   - name: libsentencepiece
     script: build-lib.sh   # [unix]
@@ -62,7 +63,9 @@ outputs:
         - "$RPATH/ld64.so.1"   # [linux and s390x]
     requirements:
       build:
-        - libprotobuf     # [build_platform != target_platform]
+        - patch       # [not win]
+        - m2-patch    # [win]
+        - libprotobuf # [build_platform != target_platform]
         - {{ compiler('cxx') }}
         #- {{ stdlib('c') }}
         - cmake


### PR DESCRIPTION
sentencepiece 0.2.0 

**Destination channel:** Defaults

### Links

- [PKG-7146]
- dev_url:        https://github.com/google/sentencepiece//tree/v0.2.0
- conda_forge:    https://github.com/conda-forge/sentencepiece-feedstock
- pypi:           https://pypi.org/project/sentencepiece/0.2.0
- pypi inspector: https://inspector.pypi.io/project/sentencepiece/0.2.0

### Explanation of changes:

- build for py313
- bump build number
- appease the linter by:
  - skipping lints (importing _something_ causes a dependency issue on `linux-aarch64`)
  - adding `patch` to `requirements.build` of, here, `libsentencepiece`

Note that we are six patches behind conda-forge.  I don't want to perturb a simple rebuild too much.


[PKG-7146]: https://anaconda.atlassian.net/browse/PKG-7146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ