### PR TITLE
rebuild python wrapper

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313: yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ source:
     - patches/0007-move-setting-of-default-CMAKE_INSTALL_-BIN-INCLUDE-L.patch
 
 build:
-  number: 4
+  number: 5
 
 outputs:
   - name: sentencepiece
@@ -45,6 +45,7 @@ outputs:
         - {{ pin_subpackage('libsentencepiece', exact=True) }}
         - {{ pin_subpackage('sentencepiece-spm', exact=True) }}
         - sentencepiece-python {{ version }} # don't pin_subpackage; that would pin to a single python version
+        - python
     test:
       commands:
         # tested in other outputs
@@ -58,20 +59,18 @@ outputs:
         # not clear what ABI-compatibility of sentencepiece versions are;
         # for now, use same version at run & build time
         - {{ pin_subpackage("libsentencepiece", max_pin="x.x.x") }}
-      missing_dso_whitelist: # [linux and s390x]
-        - "$RPATH/ld64.so.1"   # [linux and s390x]
     requirements:
       build:
         - patch       # [not win]
         - m2-patch    # [win]
         - libprotobuf # [build_platform != target_platform]
         - {{ compiler('cxx') }}
-        #- {{ stdlib('c') }}
+        - {{ stdlib('c') }}
         - cmake
         - ninja
       host:
-        - libabseil 20250127.0
-        - libprotobuf 5.29.3
+        - libabseil {{ libabseil }}
+        - libprotobuf {{ libprotobuf }}
         #- pthreads-win32  # [win]
       run:
         # sentencepiece uses PUBLIC linkage for abseil, which is correct
@@ -128,13 +127,13 @@ outputs:
       build:
         - libprotobuf     # [build_platform != target_platform]
         - {{ compiler('cxx') }}
-        #- {{ stdlib('c') }}
+        - {{ stdlib('c') }}
         - cmake
         - ninja
       host:
         - {{ pin_subpackage('libsentencepiece', exact=True) }}
-        - libabseil 20250127.0
-        - libprotobuf 5.29.3
+        - libabseil {{ libabseil }}
+        - libprotobuf {{ libprotobuf }}
         #- pthreads-win32  # [win]
       run:
         - {{ pin_subpackage('libsentencepiece', exact=True) }}
@@ -156,15 +155,15 @@ outputs:
         - python                                 # [build_platform != target_platform]
         - cross-python_{{ target_platform }}     # [build_platform != target_platform]
         - {{ compiler('cxx') }}
-        #- {{ stdlib('c') }}
+        - {{ stdlib('c') }}
         - pkg-config   # [unix]
       host:
         - pip
         - python
         - {{ pin_subpackage('libsentencepiece', exact=True) }}
-        - libprotobuf 5.29.3
+        - libprotobuf {{ libprotobuf }}
         # host deps of static libsentencepiece leak to consumers
-        - libabseil 20250127.0  # [win]
+        - libabseil {{ libabseil }}  # [win]
       run:
         - python
         - {{ pin_subpackage('libsentencepiece', exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -83,6 +83,7 @@ outputs:
         # cmake needs compiler to be able to run package detection, see
         # https://discourse.cmake.org/t/questions-about-find-package-cli-msvc/6194
         - {{ compiler('cxx') }}
+        - {{ stdlib('c') }}
         - cmake
         - ninja
         - pkg-config
@@ -132,7 +133,6 @@ outputs:
         - {{ pin_subpackage('libsentencepiece', exact=True) }}
         - libabseil {{ libabseil }}
         - libprotobuf {{ libprotobuf }}
-        #- pthreads-win32  # [win]
       run:
         - {{ pin_subpackage('libsentencepiece', exact=True) }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,8 +61,6 @@ outputs:
         - {{ pin_subpackage("libsentencepiece", max_pin="x.x.x") }}
     requirements:
       build:
-        - patch       # [not win]
-        - m2-patch    # [win]
         - libprotobuf # [build_platform != target_platform]
         - {{ compiler('cxx') }}
         - {{ stdlib('c') }}


### PR DESCRIPTION
### Explanation of changes:

- Rebuilding because sentencepiece was pinned to a specific python version, rather than for all supported.

https://anaconda.atlassian.net/browse/PKG-9731

Required for: https://github.com/AnacondaRecipes/llama.cpp-feedstock/pull/18