### PR TITLE
sentencepiece 0.2.1: rebuild-py314

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   patches:
     # trying to build both static & shared build seems to break on OSX
     - patches/0001-do-not-mix-static-shared-builds.patch
-    # Fix symlink creation failure on Windows 
+    # Fix symlink creation failure on Windows
     - patches/0001-fix-failing-symlink-creation.patch  # [win]
     # set PROTOBUF_USE_DLLS
     - patches/0002-ensure-we-set-PROTOBUF_USE_DLLS-when-using-our-own-p.patch
@@ -24,7 +24,7 @@ source:
     - patches/0006-also-link-to-static-absl_flags_-on-windows.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: sentencepiece
@@ -43,15 +43,14 @@ outputs:
       run:
         - {{ pin_subpackage('libsentencepiece', exact=True) }}
         - {{ pin_subpackage('sentencepiece-spm', exact=True) }}
-        - sentencepiece-python {{ version }} # don't pin_subpackage; that would pin to a single python version
+        - sentencepiece-python {{ version }}  # don't pin_subpackage; that would pin to a single python version
         - python
     test:
       commands:
         # tested in other outputs
         - exit 0
-
   - name: libsentencepiece
-    script: build-lib.sh   # [unix]
+    script: build-lib.sh  # [unix]
     script: build-lib.bat  # [win]
     build:
       run_exports:
@@ -60,7 +59,7 @@ outputs:
         - {{ pin_subpackage("libsentencepiece", max_pin="x.x.x") }}
     requirements:
       build:
-        - libprotobuf # [build_platform != target_platform]
+        - libprotobuf  # [build_platform != target_platform]
         - {{ compiler('cxx') }}
         - {{ stdlib('c') }}
         - cmake
@@ -68,15 +67,14 @@ outputs:
       host:
         - libabseil {{ libabseil }}
         - libprotobuf {{ libprotobuf }}
-        #- pthreads-win32  # [win]
+      #- pthreads-win32  # [win]
       run:
         # sentencepiece uses PUBLIC linkage for abseil, which is correct
         # (unfortunately) because it contains abseil types in its API
         - libabseil
         # additionally, the static windows build requires _its_
         # host dependences to be present for successful linkage
-        - libprotobuf     # [win]
-
+        - libprotobuf  # [win]
     test:
       requires:
         # cmake needs compiler to be able to run package detection, see
@@ -93,37 +91,27 @@ outputs:
         - test_sentencepiece.sh
         - test_sentencepiece.bat
       commands:
-        {% for each_lib in ["sentencepiece", "sentencepiece_train"] %}
         # presence of shared libraries
-        - test -f $PREFIX/lib/lib{{ each_lib }}.so              # [linux]
-        - test -f $PREFIX/lib/lib{{ each_lib }}.dylib           # [osx]
-
+        - test -f $PREFIX/lib/lib{{ each_lib }}.so  # [linux]
+        - test -f $PREFIX/lib/lib{{ each_lib }}.dylib  # [osx]
         # static libraries on windows
         - if not exist %LIBRARY_LIB%\{{ each_lib }}.lib exit 1  # [win]
-
         # absence of static libraries (on unix)
-        - test ! -f $PREFIX/lib/lib{{ each_lib }}.a             # [unix]
-        {% endfor %}
-
+        - test ! -f $PREFIX/lib/lib{{ each_lib }}.a  # [unix]
         # headers
-        {% for each_header in ["sentencepiece_processor.h", "sentencepiece_trainer.h"] %}
         - test -f $PREFIX/include//{{ each_header }} || (echo "{{ each_header }} not found" && exit 1)  # [unix]
-        - if not exist %LIBRARY_INC%\\{{ each_header }} exit 1                                          # [win]
-        {% endfor %}
-
+        - if not exist %LIBRARY_INC%\\{{ each_header }} exit 1  # [win]
         # pkg-config
         - pkg-config --print-errors --exact-version "{{ version }}" sentencepiece
-
         # minimal CMake test (using find_package)
-        - ./test_sentencepiece.sh   # [unix]
+        - ./test_sentencepiece.sh  # [unix]
         - ./test_sentencepiece.bat  # [win]
-
   - name: sentencepiece-spm
-    script: build-lib.sh   # [unix]
+    script: build-lib.sh  # [unix]
     script: build-lib.bat  # [win]
     requirements:
       build:
-        - libprotobuf     # [build_platform != target_platform]
+        - libprotobuf  # [build_platform != target_platform]
         - {{ compiler('cxx') }}
         - {{ stdlib('c') }}
         - cmake
@@ -134,26 +122,22 @@ outputs:
         - libprotobuf {{ libprotobuf }}
       run:
         - {{ pin_subpackage('libsentencepiece', exact=True) }}
-
     test:
       commands:
         # binaries
-        {% for each_bin in ["decode", "encode", "export_vocab", "normalize", "train"] %}
         # expect exit code 1, see https://github.com/google/sentencepiece/issues/978
-        - spm_{{ each_bin }} --help >/dev/null || [[ $? == 1 ]]                     # [unix]
+        - spm_{{ each_bin }} --help >/dev/null || [[ $? == 1 ]]  # [unix]
         - spm_{{ each_bin }} --help & if %ERRORLEVEL% NEQ 1 (exit 0) else (exit 1)  # [win]
-        {% endfor %}
-
   - name: sentencepiece-python
-    script: build-pkg.sh   # [unix]
+    script: build-pkg.sh  # [unix]
     script: build-pkg.bat  # [win]
     requirements:
       build:
-        - python                                 # [build_platform != target_platform]
-        - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+        - python  # [build_platform != target_platform]
+        - cross-python_{{ target_platform }}  # [build_platform != target_platform]
         - {{ compiler('cxx') }}
         - {{ stdlib('c') }}
-        - pkg-config   # [unix]
+        - pkg-config  # [unix]
       host:
         - pip
         - python
@@ -164,7 +148,6 @@ outputs:
       run:
         - python
         - {{ pin_subpackage('libsentencepiece', exact=True) }}
-
     test:
       imports:
         - sentencepiece
@@ -205,6 +188,5 @@ extra:
     - ndmaxar
     - oblute
     - h-vetinari
-
   skip-lints:
     - missing_imports_or_run_test_py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -94,18 +94,16 @@ outputs:
         # presence of shared libraries
         - test -f $PREFIX/lib/lib{{ each_lib }}.so              # [linux]
         - test -f $PREFIX/lib/lib{{ each_lib }}.dylib           # [osx]
-        - if not exist %LIBRARY_BIN%\{{ each_lib }}.dll exit 1  # [win]
-        - if not exist %LIBRARY_LIB%\{{ each_lib }}_import.lib exit 1  # [win]
 
-        # absence of static libraries
+        # static libraries on windows
+        - if not exist %LIBRARY_LIB%\{{ each_lib }}.lib exit 1  # [win]
+
+        # absence of static libraries (on unix)
         - test ! -f $PREFIX/lib/lib{{ each_lib }}.a             # [unix]
-        - if exist %LIBRARY_LIB%\{{ each_lib }}.lib exit 1      # [win]
         {% endfor %}
 
         # headers
-        {% for each_header in [
-            "sentencepiece.pb.h", "sentencepiece_model.pb.h", "sentencepiece_processor.h", "sentencepiece_trainer.h"
-        ] %}
+        {% for each_header in ["sentencepiece_processor.h", "sentencepiece_trainer.h"] %}
         - test -f $PREFIX/include//{{ each_header }} || (echo "{{ each_header }} not found" && exit 1)  # [unix]
         - if not exist %LIBRARY_INC%\\{{ each_header }} exit 1                                          # [win]
         {% endfor %}
@@ -163,6 +161,7 @@ outputs:
         - libprotobuf {{ libprotobuf }}
         # host deps of static libsentencepiece leak to consumers
         - libabseil {{ libabseil }}  # [win]
+        - setuptools
       run:
         - python
         - {{ pin_subpackage('libsentencepiece', exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,7 +67,6 @@ outputs:
       host:
         - libabseil {{ libabseil }}
         - libprotobuf {{ libprotobuf }}
-      #- pthreads-win32  # [win]
       run:
         # sentencepiece uses PUBLIC linkage for abseil, which is correct
         # (unfortunately) because it contains abseil types in its API
@@ -91,21 +90,33 @@ outputs:
         - test_sentencepiece.sh
         - test_sentencepiece.bat
       commands:
+        {% for each_lib in ["sentencepiece", "sentencepiece_train"] %}
         # presence of shared libraries
-        - test -f $PREFIX/lib/lib{{ each_lib }}.so  # [linux]
-        - test -f $PREFIX/lib/lib{{ each_lib }}.dylib  # [osx]
-        # static libraries on windows
-        - if not exist %LIBRARY_LIB%\{{ each_lib }}.lib exit 1  # [win]
-        # absence of static libraries (on unix)
-        - test ! -f $PREFIX/lib/lib{{ each_lib }}.a  # [unix]
+        - test -f $PREFIX/lib/lib{{ each_lib }}.so              # [linux]
+        - test -f $PREFIX/lib/lib{{ each_lib }}.dylib           # [osx]
+        - if not exist %LIBRARY_BIN%\{{ each_lib }}.dll exit 1  # [win]
+        - if not exist %LIBRARY_LIB%\{{ each_lib }}_import.lib exit 1  # [win]
+
+        # absence of static libraries
+        - test ! -f $PREFIX/lib/lib{{ each_lib }}.a             # [unix]
+        - if exist %LIBRARY_LIB%\{{ each_lib }}.lib exit 1      # [win]
+        {% endfor %}
+
         # headers
+        {% for each_header in [
+            "sentencepiece.pb.h", "sentencepiece_model.pb.h", "sentencepiece_processor.h", "sentencepiece_trainer.h"
+        ] %}
         - test -f $PREFIX/include//{{ each_header }} || (echo "{{ each_header }} not found" && exit 1)  # [unix]
-        - if not exist %LIBRARY_INC%\\{{ each_header }} exit 1  # [win]
+        - if not exist %LIBRARY_INC%\\{{ each_header }} exit 1                                          # [win]
+        {% endfor %}
+
         # pkg-config
         - pkg-config --print-errors --exact-version "{{ version }}" sentencepiece
+
         # minimal CMake test (using find_package)
-        - ./test_sentencepiece.sh  # [unix]
+        - ./test_sentencepiece.sh   # [unix]
         - ./test_sentencepiece.bat  # [win]
+
   - name: sentencepiece-spm
     script: build-lib.sh  # [unix]
     script: build-lib.bat  # [win]
@@ -125,9 +136,16 @@ outputs:
     test:
       commands:
         # binaries
+        {% for each_bin in ["decode", "encode", "export_vocab", "normalize", "train"] %}
         # expect exit code 1, see https://github.com/google/sentencepiece/issues/978
-        - spm_{{ each_bin }} --help >/dev/null || [[ $? == 1 ]]  # [unix]
-        - spm_{{ each_bin }} --help & if %ERRORLEVEL% NEQ 1 (exit 0) else (exit 1)  # [win]
+        - spm_{{ each_bin }} --help >/dev/null || [[ $? == 1 ]]                     # [unix]
+        # do not use %ERRORLEVEL% or !ERRORLEVEL!, but ERRORLEVEL, c.f.
+        # https://devblogs.microsoft.com/oldnewthing/20080926-00/?p=20743;
+        # while `if ... NEQ 1 exit 1` would be nicer, NEQ is incompatible with
+        # using bare ERRORLEVEL, see https://stackoverflow.com/a/74148543
+        - spm_{{ each_bin }} --help & if ERRORLEVEL ==1 (exit 0) else (exit 1)      # [win]
+        {% endfor %}
+
   - name: sentencepiece-python
     script: build-pkg.sh  # [unix]
     script: build-pkg.bat  # [win]


### PR DESCRIPTION
**Destination channel:** main

### Links

- [Jira](https://anaconda.atlassian.net/browse/PKG-11326) 
- [Upstream repository](https://github.com/google/sentencepiece//tree/v0.2.1)

### Explanation of changes:

- Apply anaconda-linter to clean up the recipe
- Add missing `setuptools` to the `sentencepiece-python` subpackage

### Notes:

-