### PR TITLE
Rebuild against libprotobuf and libabseil

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,3 @@
 # On CI, this value is sometimes not read from the CBC file for some reason. This is a workaround.
-libabseil: 20250814.1
+libabseil: 20260107.0
+libprotobuf: 6.33.5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ source:
     - patches/0006-also-link-to-static-absl_flags_-on-windows.patch
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: sentencepiece
@@ -59,7 +59,6 @@ outputs:
         - {{ pin_subpackage("libsentencepiece", max_pin="x.x.x") }}
     requirements:
       build:
-        - libprotobuf  # [build_platform != target_platform]
         - {{ compiler('cxx') }}
         - {{ stdlib('c') }}
         - cmake
@@ -120,7 +119,6 @@ outputs:
     script: build-lib.bat  # [win]
     requirements:
       build:
-        - libprotobuf  # [build_platform != target_platform]
         - {{ compiler('cxx') }}
         - {{ stdlib('c') }}
         - cmake
@@ -149,8 +147,6 @@ outputs:
     script: build-pkg.bat  # [win]
     requirements:
       build:
-        - python  # [build_platform != target_platform]
-        - cross-python_{{ target_platform }}  # [build_platform != target_platform]
         - {{ compiler('cxx') }}
         - {{ stdlib('c') }}
         - pkg-config  # [unix]


### PR DESCRIPTION
sentencepiece 0.2.1

**Destination channel:**  defaults

### Links

- [PKG-12372](https://anaconda.atlassian.net/browse/PKG-12372) 
- [Upstream repository](https://github.com/google/sentencepiece/tree/v0.2.1)

### Explanation of changes:
- Rebuild against libprotobuf and libabseil


[PKG-12372]: https://anaconda.atlassian.net/browse/PKG-12372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ