### PR TITLE
PKG-15924: rebuild sentencepiece 0.2.1 against libprotobuf 7.35.1

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,0 @@
-# On CI, this value is sometimes not read from the CBC file for some reason. This is a workaround.
-libabseil: 20260107.0
-libprotobuf: 6.33.5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ source:
     - patches/0006-also-link-to-static-absl_flags_-on-windows.patch
 
 build:
-  number: 2
+  number: 3
 
 outputs:
   - name: sentencepiece
@@ -64,8 +64,8 @@ outputs:
         - cmake
         - ninja
       host:
-        - libabseil {{ libabseil }}
-        - libprotobuf {{ libprotobuf }}
+        - libabseil 20260526.0
+        - libprotobuf 7.35.1
       run:
         # sentencepiece uses PUBLIC linkage for abseil, which is correct
         # (unfortunately) because it contains abseil types in its API
@@ -125,8 +125,8 @@ outputs:
         - ninja
       host:
         - {{ pin_subpackage('libsentencepiece', exact=True) }}
-        - libabseil {{ libabseil }}
-        - libprotobuf {{ libprotobuf }}
+        - libabseil 20260526.0
+        - libprotobuf 7.35.1
       run:
         - {{ pin_subpackage('libsentencepiece', exact=True) }}
     test:
@@ -154,9 +154,9 @@ outputs:
         - pip
         - python
         - {{ pin_subpackage('libsentencepiece', exact=True) }}
-        - libprotobuf {{ libprotobuf }}
+        - libprotobuf 7.35.1
         # host deps of static libsentencepiece leak to consumers
-        - libabseil {{ libabseil }}  # [win]
+        - libabseil 20260526.0  # [win]
         - setuptools
       run:
         - python


### PR DESCRIPTION
## Version
- `sentencepiece` `0.2.1` (rebuild)

## Destination channel
- `main`

## Links
- Jira: [PKG-15924](https://anaconda.atlassian.net/browse/PKG-15924)
- PyPI: N/A
- GitHub: [https://github.com/google/sentencepiece/releases/tag/v0.2.1](https://github.com/google/sentencepiece/releases/tag/v0.2.1)

## Explanation of changes
- Rebuilds `sentencepiece` `0.2.1` against the Stage 002 abseil/libprotobuf pins for the protobuf migration epic.
- - Hardcodes `libprotobuf` `7.35.1` and `libabseil` `20260526.0` (no feedstock CBC version pins).
[PKG-15924]: https://anaconda.atlassian.net/browse/PKG-15924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
